### PR TITLE
#6 and esm/umd/cjs builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "yoffee",
   "version": "0.0.7",
   "description": "Minimal HTML one-way binding library",
-  "module": "src/yoffee.js",
+  "main": "dist/yoffe.min.js",
+  "module": "dist/yoffee.min.js",
   "type": "module",
   "scripts": {
     "test": "mocha -r jsdom-global/register",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "mocha -r jsdom-global/register",
     "build": "node webpack.config.js",
+    "build-rollup": "rollup -c",
     "upload": "npm publish --access=public"
   },
   "author": {
@@ -39,9 +40,14 @@
     "web components"
   ],
   "devDependencies": {
+    "@rollup/plugin-strip": "^2.1.0",
     "jsdom": "16.2.2",
     "jsdom-global": "3.0.2",
     "mocha": "^7.1.1",
+    "rollup": "^2.66.1",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-uglify": "^6.0.4",
     "terser-webpack-plugin": "^2.3.5",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,49 @@
+import { terser } from 'rollup-plugin-terser';
+import commonjs from 'rollup-plugin-commonjs';
+import { uglify } from 'rollup-plugin-uglify';
+import strip from '@rollup/plugin-strip';
+
+const production = !process.env.ROLLUP_WATCH;
+
+
+export default {
+    input: './src/yoffee.js',
+    output: [{
+        file: './dist/yoffee.iife.js',
+        format: 'iife',
+        name: 'iife'
+    },
+    {
+        file: './dist/yoffee.esm.js',
+        format: 'esm',
+        name: 'esm'
+    },
+    {
+        file: './dist/yoffee.umd.js',
+        format: 'umd',
+        name: 'umd'
+    },
+    {
+        file: './dist/yoffee.cjs.js',
+        format: 'cjs',
+        name: 'cjs'
+    },
+    {
+        file: './dist/yoffee.js.map',
+        sourcemap: 'inline'
+    }],
+    plugins: [
+        strip(),
+        production && terser({
+            format: {
+                comments: false
+            },
+            compress: true,
+                mangle: {
+                    reserved: ["yoffee", "exports", "replaceWith"],
+                } 
+        }),
+        commonjs(),
+        uglify()
+    ]
+}


### PR DESCRIPTION
- Remove console log when imported as root ES module
- Changes module to use dist minimized yoffee
- Adds esm/umd/cjs specific builds
- Adds js map
- Reduces library size by ~8%

| Type  | Original (webpack) size | Rollup Byte Size | Original (webpack) Gzipped size | Rollup Gziped Byte size 
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Original | 13,588  | 12,419 | 4,511 | 4,161 |
| ESM       | - |  12,380| - | 4,127 |
| UMD      | - | 12,607 | -| 4228 |
| CJS        | - | 12,449| - | 4,164 |
| IIFE.        | - | 12,419 | - |  4,161 |

```bash
$ npm run build-rollup && ls dist/
13588  yoffee.min.js
12380 yoffee.esm.js
12449 yoffee.cjs.js
12419 yoffee.iife.js
12607 yoffee.umd.js
4127 yoffee.esm.js.gz
4164  yoffee.cjs.js.gz
4161  yoffee.iife.js.gz
4228 yoffee.umd.js.gz
4511  yoffee.min.js.gz
```